### PR TITLE
Add address guard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-visualizers",
-  "version": "0.0.2",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-visualizers",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "homepage": "https://github.com/synthetichealth/fhir-visualizers",
   "description": "Simple React-based FHIR Visualizers",
   "license": "Apache-2.0",

--- a/src/index.js
+++ b/src/index.js
@@ -100,7 +100,7 @@ class PatientVisualizer extends React.Component {
     const cause_of_death_obs = null;
 
     let lat, lng;
-    if (patient.address[0].extension) {
+    if (patient.address && patient.address[0].extension) {
       const geolocation = patient.address[0].extension.find(e => e.url === 'http://hl7.org/fhir/StructureDefinition/geolocation');
 
       if (geolocation && geolocation.extension.length > 1) {


### PR DESCRIPTION
Add additional guard on patient.address such that if address is missing (0..* cardinality according to FHIR spec), the component does not crash due to `cannot read property [0] of undefined`